### PR TITLE
Add methods that take Merlin transcript as param to VRF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (TESTING)
   )
 endif ()
 
-project(schnorrkel-crust CXX)
+project(schnorrkel-crust C CXX)
 
 include(FindPackageHandleStandardArgs)
 include(cmake/functions.cmake)
@@ -25,7 +25,7 @@ include(cmake/rust.cmake)
 
 if (NOT EXISTS "${CMAKE_TOOLCHAIN_FILE}")
   # https://cgold.readthedocs.io/en/latest/tutorials/toolchain/globals/cxx-standard.html#summary
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "staticlib"]
 schnorrkel = { version="0.9.1" }
 ed25519-dalek = { version="1.0.0" }
 rand_chacha = "0.2.2"
+merlin = { version = "2.0", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.1"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,9 @@ hunter_add_package(GTest)
 find_package(GTest CONFIG REQUIRED)
 find_package(GMock CONFIG REQUIRED)
 
+hunter_add_package(Microsoft.GSL)
+find_package(Microsoft.GSL CONFIG REQUIRED)
+
 if(TARGET schnorrkel_crust)
     message(INFO Found)
 endif()
@@ -12,6 +15,7 @@ addtest(sr25519_test
         sr25519/derive.cpp
         sr25519/keypair_from_seed.cpp
         sr25519/vrf.cpp
+        sr25519/keccak.c
     )
 target_link_libraries(sr25519_test
     schnorrkel_crust

--- a/test/ed25519/test.cpp
+++ b/test/ed25519/test.cpp
@@ -13,7 +13,7 @@ extern "C" {
 }
 
 TEST(Ed25519, GenerateKeypair) {
-  std::array<uint8_t, ED25519_KEYPAIR_LENGTH> keypair;
+  std::array<uint8_t, ED25519_KEYPAIR_LENGTH> keypair {};
   std::array<uint8_t, ED25519_SEED_LENGTH> seed = {42, 1, 2, 3, 4, 5};
   ed25519_keypair_from_seed(keypair.data(), seed.data());
   ASSERT_THAT(keypair, testing::Contains(testing::Not(0)));

--- a/test/sr25519/ds.cpp
+++ b/test/sr25519/ds.cpp
@@ -3,15 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "../utils.hpp"
 #include <gtest/gtest.h>
+
+#include "../utils.hpp"
 
 extern "C" {
 #include <schnorrkel/schnorrkel.h>
 }
 
 TEST(sr25519, SignAndVerifyValid) {
-  auto kp = randomKeypair();
+  auto kp = randomKeypair(SR25519_KEYPAIR_SIZE, sr25519_keypair_from_seed);
   auto msg = "hello world"_v;
 
   std::vector<uint8_t> sig(SR25519_SIGNATURE_SIZE, 0);
@@ -27,7 +28,7 @@ TEST(sr25519, SignAndVerifyValid) {
 }
 
 TEST(sr25519, SignAndVerifyInvalid) {
-  auto kp = randomKeypair(0);
+  auto kp = randomKeypair(0, sr25519_keypair_from_seed);
   auto msg = "hello world"_v;
 
   std::vector<uint8_t> sig(SR25519_SIGNATURE_SIZE, 0);

--- a/test/sr25519/endianness_utils.hpp
+++ b/test/sr25519/endianness_utils.hpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SCHNORRKEL_CRUST_ENDIANNESS_UTILS_HPP
+#define SCHNORRKEL_CRUST_ENDIANNESS_UTILS_HPP
+
+#ifdef _MSC_VER
+#define LE_BE_SWAP32 _byteswap_ulong
+#define LE_BE_SWAP64 _byteswap_uint64
+#else  //_MSC_VER
+#define LE_BE_SWAP32 __builtin_bswap32
+#define LE_BE_SWAP64 __builtin_bswap64
+#endif  //_MSC_VER
+
+#endif // SCHNORRKEL_CRUST_ENDIANNESS_UTILS_HPP

--- a/test/sr25519/keccak.c
+++ b/test/sr25519/keccak.c
@@ -1,0 +1,306 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "keccak.h"
+#include "endianness_utils.hpp"
+
+#define SHA3_ASSERT(x)
+#if defined(_MSC_VER)
+#define SHA3_TRACE(format, ...)
+#define SHA3_TRACE_BUF(format, buf, l, ...)
+#else
+#define SHA3_TRACE(format, args...)
+#define SHA3_TRACE_BUF(format, buf, l, args...)
+#endif
+
+/*
+ * This flag is used to configure "pure" Keccak, as opposed to NIST SHA3.
+ */
+#define SHA3_USE_KECCAK_FLAG 0x80000000
+#define SHA3_CW(x) ((x) & (~SHA3_USE_KECCAK_FLAG))
+
+#if defined(_MSC_VER)
+#define SHA3_CONST(x) x
+#else
+#define SHA3_CONST(x) x##L
+#endif
+
+#ifndef SHA3_ROTL64
+#define SHA3_ROTL64(x, y) \
+  (((x) << (y)) | ((x) >> ((sizeof(uint64_t) * 8) - (y))))
+#endif
+
+static const uint64_t keccakf_rndc[24] = {
+    SHA3_CONST(0x0000000000000001UL), SHA3_CONST(0x0000000000008082UL),
+    SHA3_CONST(0x800000000000808aUL), SHA3_CONST(0x8000000080008000UL),
+    SHA3_CONST(0x000000000000808bUL), SHA3_CONST(0x0000000080000001UL),
+    SHA3_CONST(0x8000000080008081UL), SHA3_CONST(0x8000000000008009UL),
+    SHA3_CONST(0x000000000000008aUL), SHA3_CONST(0x0000000000000088UL),
+    SHA3_CONST(0x0000000080008009UL), SHA3_CONST(0x000000008000000aUL),
+    SHA3_CONST(0x000000008000808bUL), SHA3_CONST(0x800000000000008bUL),
+    SHA3_CONST(0x8000000000008089UL), SHA3_CONST(0x8000000000008003UL),
+    SHA3_CONST(0x8000000000008002UL), SHA3_CONST(0x8000000000000080UL),
+    SHA3_CONST(0x000000000000800aUL), SHA3_CONST(0x800000008000000aUL),
+    SHA3_CONST(0x8000000080008081UL), SHA3_CONST(0x8000000000008080UL),
+    SHA3_CONST(0x0000000080000001UL), SHA3_CONST(0x8000000080008008UL)};
+
+static const unsigned keccakf_rotc[24] = {1,  3,  6,  10, 15, 21, 28, 36,
+                                          45, 55, 2,  14, 27, 41, 56, 8,
+                                          25, 43, 62, 18, 39, 61, 20, 44};
+
+static const unsigned keccakf_piln[24] = {10, 7,  11, 17, 18, 3,  5,  16,
+                                          8,  21, 24, 4,  15, 23, 19, 13,
+                                          12, 2,  20, 14, 22, 9,  6,  1};
+
+/* generally called after SHA3_KECCAK_SPONGE_WORDS-ctx->capacityWords words
+ * are XORed into the state s
+ */
+void keccakf(uint64_t s[25]) {
+  int i, j, round;    // NOLINT
+  uint64_t t, bc[5];  // NOLINT
+#define KECCAK_ROUNDS 24
+
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+  for (i = 0; i < 25; i++) {
+    s[i] = LE_BE_SWAP64(s[i]);
+  }
+#endif
+
+  for (round = 0; round < KECCAK_ROUNDS; round++) {
+    /* Theta */
+    for (i = 0; i < 5; i++)
+      bc[i] = s[i] ^ s[i + 5] ^ s[i + 10] ^ s[i + 15] ^ s[i + 20];
+
+    for (i = 0; i < 5; i++) {
+      t = bc[(i + 4) % 5] ^ SHA3_ROTL64(bc[(i + 1) % 5], 1);
+      for (j = 0; j < 25; j += 5) s[j + i] ^= t;
+    }
+
+    /* Rho Pi */
+    t = s[1];
+    for (i = 0; i < 24; i++) {
+      j = keccakf_piln[i];  // NOLINT
+      bc[0] = s[j];
+      s[j] = SHA3_ROTL64(t, keccakf_rotc[i]);
+      t = bc[0];
+    }
+
+    /* Chi */
+    for (j = 0; j < 25; j += 5) {
+      for (i = 0; i < 5; i++) bc[i] = s[j + i];
+      for (i = 0; i < 5; i++) s[j + i] ^= (~bc[(i + 1) % 5]) & bc[(i + 2) % 5];
+    }
+
+    /* Iota */
+    s[0] ^= keccakf_rndc[round];
+  }
+
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+  for (i = 0; i < 25; i++) {
+    s[i] = LE_BE_SWAP64(s[i]);
+  }
+#endif
+}
+
+/* *************************** Public Inteface ************************ */
+
+/* For Init or Reset call these: */
+sha3_return_t sha3_Init(void *priv, unsigned bitSize) {
+  sha3_context *ctx = (sha3_context *)priv;
+  if (bitSize != 256 && bitSize != 384 && bitSize != 512)
+    return SHA3_RETURN_BAD_PARAMS;
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->capacityWords = 2 * bitSize / (8 * sizeof(uint64_t));
+  return SHA3_RETURN_OK;
+}
+
+void sha3_Init256(void *priv) {
+  sha3_Init(priv, 256);
+}
+
+void sha3_Init384(void *priv) {
+  sha3_Init(priv, 384);
+}
+
+void sha3_Init512(void *priv) {
+  sha3_Init(priv, 512);
+}
+
+enum SHA3_FLAGS sha3_SetFlags(void *priv, enum SHA3_FLAGS flags) {
+  sha3_context *ctx = (sha3_context *)priv;
+  flags &= SHA3_FLAGS_KECCAK;
+  ctx->capacityWords |= (flags == SHA3_FLAGS_KECCAK ? SHA3_USE_KECCAK_FLAG : 0);
+  return flags;
+}
+
+void sha3_Update(void *priv, void const *bufIn, size_t len) {
+  sha3_context *ctx = (sha3_context *)priv;
+
+  /* 0...7 -- how much is needed to have a word */
+  unsigned old_tail = (8 - ctx->byteIndex) & 7;
+
+  size_t words;
+  unsigned tail;
+  size_t i;
+
+  const uint8_t *buf = bufIn;
+
+  SHA3_TRACE_BUF("called to update with:", buf, len);
+
+  SHA3_ASSERT(ctx->byteIndex < 8);
+  SHA3_ASSERT(ctx->wordIndex < sizeof(ctx->s) / sizeof(ctx->s[0]));
+
+  if (len < old_tail) { /* have no complete word or haven't started
+                         * the word yet */
+    SHA3_TRACE("because %d<%d, store it and return",
+               (unsigned)len,
+               (unsigned)old_tail);
+    /* endian-independent code follows: */
+    while (len--)
+      ctx->saved |= (uint64_t)(*(buf++)) << ((ctx->byteIndex++) * 8);
+    SHA3_ASSERT(ctx->byteIndex < 8);
+    return;
+  }
+
+  if (old_tail) { /* will have one word to process */
+    SHA3_TRACE("completing one word with %d bytes", (unsigned)old_tail);
+    /* endian-independent code follows: */
+    len -= old_tail;
+    while (old_tail--)
+      ctx->saved |= (uint64_t)(*(buf++)) << ((ctx->byteIndex++) * 8);
+
+    /* now ready to add saved to the sponge */
+    ctx->s[ctx->wordIndex] ^= ctx->saved;
+    SHA3_ASSERT(ctx->byteIndex == 8);
+    ctx->byteIndex = 0;
+    ctx->saved = 0;
+    if (++ctx->wordIndex
+        == (SHA3_KECCAK_SPONGE_WORDS - SHA3_CW(ctx->capacityWords))) {
+      keccakf(ctx->s);
+      ctx->wordIndex = 0;
+    }
+  }
+
+  /* now work in full words directly from input */
+
+  SHA3_ASSERT(ctx->byteIndex == 0);
+
+  words = len / sizeof(uint64_t);
+  tail = len - words * sizeof(uint64_t);
+
+  SHA3_TRACE("have %d full words to process", (unsigned)words);
+
+  for (i = 0; i < words; i++, buf += sizeof(uint64_t)) {
+    const uint64_t t =
+        (uint64_t)(buf[0]) | ((uint64_t)(buf[1]) << 8 * 1)
+        | ((uint64_t)(buf[2]) << 8 * 2) | ((uint64_t)(buf[3]) << 8 * 3)
+        | ((uint64_t)(buf[4]) << 8 * 4) | ((uint64_t)(buf[5]) << 8 * 5)
+        | ((uint64_t)(buf[6]) << 8 * 6) | ((uint64_t)(buf[7]) << 8 * 7);
+#if defined(__x86_64__) || defined(__i386__)
+    SHA3_ASSERT(memcmp(&t, buf, 8) == 0);
+#endif
+    ctx->s[ctx->wordIndex] ^= t;
+    if (++ctx->wordIndex
+        == (SHA3_KECCAK_SPONGE_WORDS - SHA3_CW(ctx->capacityWords))) {
+      keccakf(ctx->s);
+      ctx->wordIndex = 0;
+    }
+  }
+
+  SHA3_TRACE("have %d bytes left to process, save them", (unsigned)tail);
+
+  /* finally, save the partial word */
+  SHA3_ASSERT(ctx->byteIndex == 0 && tail < 8);
+  while (tail--) {
+    SHA3_TRACE("Store byte %02x '%c'", *buf, *buf);
+    ctx->saved |= (uint64_t)(*(buf++)) << ((ctx->byteIndex++) * 8);
+  }
+  SHA3_ASSERT(ctx->byteIndex < 8);
+  SHA3_TRACE("Have saved=0x%016" PRIx64 " at the end", ctx->saved);
+}
+
+/* This is simply the 'update' with the padding block.
+ * The padding block is 0x01 || 0x00* || 0x80. First 0x01 and last 0x80
+ * bytes are always present, but they can be the same byte.
+ */
+void const *sha3_Finalize(void *priv) {
+  sha3_context *ctx = (sha3_context *)priv;
+
+  SHA3_TRACE("called with %d bytes in the buffer", ctx->byteIndex);
+
+  /* Append 2-bit suffix 01, per SHA-3 spec. Instead of 1 for padding we
+   * use 1<<2 below. The 0x02 below corresponds to the suffix 01.
+   * Overall, we feed 0, then 1, and finally 1 to start padding. Without
+   * M || 01, we would simply use 1 to start padding. */
+
+  uint64_t t;
+
+  if (ctx->capacityWords & SHA3_USE_KECCAK_FLAG) {
+    /* Keccak version */
+    t = (uint64_t)(((uint64_t)1) << (ctx->byteIndex * 8));  // NOLINT
+  } else {
+    /* SHA3 version */
+    t = (uint64_t)(((uint64_t)(0x02 | (1 << 2)))  // NOLINT
+                       << ((ctx->byteIndex) * 8));    // NOLINT
+  }
+
+  ctx->s[ctx->wordIndex] ^= ctx->saved ^ t;
+
+  ctx->s[SHA3_KECCAK_SPONGE_WORDS - SHA3_CW(ctx->capacityWords) - 1] ^=
+      SHA3_CONST(0x8000000000000000UL);
+  keccakf(ctx->s);
+
+  /* Return first bytes of the ctx->s. This conversion is not needed for
+   * little-endian platforms e.g. wrap with #if !defined(__BYTE_ORDER__)
+   * || !defined(__ORDER_LITTLE_ENDIAN__) ||
+   * __BYTE_ORDER__!=__ORDER_LITTLE_ENDIAN__
+   *    ... the conversion below ...
+   * #endif */
+  {
+    unsigned i;
+    for (i = 0; i < SHA3_KECCAK_SPONGE_WORDS; i++) {  // NOLINT
+      const unsigned t1 = (uint32_t)ctx->s[i];
+      const unsigned t2 = (uint32_t)((ctx->s[i] >> 16) >> 16);
+      ctx->sb[i * 8 + 0] = (uint8_t)(t1);
+      ctx->sb[i * 8 + 1] = (uint8_t)(t1 >> 8);
+      ctx->sb[i * 8 + 2] = (uint8_t)(t1 >> 16);
+      ctx->sb[i * 8 + 3] = (uint8_t)(t1 >> 24);
+      ctx->sb[i * 8 + 4] = (uint8_t)(t2);
+      ctx->sb[i * 8 + 5] = (uint8_t)(t2 >> 8);
+      ctx->sb[i * 8 + 6] = (uint8_t)(t2 >> 16);
+      ctx->sb[i * 8 + 7] = (uint8_t)(t2 >> 24);
+    }
+  }
+
+  SHA3_TRACE_BUF("Hash: (first 32 bytes)", ctx->sb, 256 / 8);
+
+  return (ctx->sb);
+}
+
+sha3_return_t sha3_HashBuffer(unsigned bitSize,
+                              enum SHA3_FLAGS flags,
+                              const void *in,
+                              unsigned inBytes,
+                              void *out,
+                              unsigned outBytes) {
+  sha3_return_t err;
+  sha3_context c;
+
+  err = sha3_Init(&c, bitSize);
+  if (err != SHA3_RETURN_OK) return err;
+  if (sha3_SetFlags(&c, flags) != flags) {
+    return SHA3_RETURN_BAD_PARAMS;
+  }
+  sha3_Update(&c, in, inBytes);
+  const void *h = sha3_Finalize(&c);
+
+  if (outBytes > bitSize / 8) outBytes = bitSize / 8;
+  memcpy(out, h, outBytes);
+  return SHA3_RETURN_OK;
+}

--- a/test/sr25519/keccak.h
+++ b/test/sr25519/keccak.h
@@ -1,0 +1,63 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SCHNORRKEL_CRUST_KECCAK_H
+#define SCHNORRKEL_CRUST_KECCAK_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/* 'Words' here refers to uint64_t */
+#define SHA3_KECCAK_SPONGE_WORDS \
+  (((1600) / 8 /*bits to byte*/) / sizeof(uint64_t))
+typedef struct sha3_context_ {
+  uint64_t saved; /* the portion of the input message that we
+                   * didn't consume yet */
+  union {         /* Keccak's state */
+    uint64_t s[SHA3_KECCAK_SPONGE_WORDS];
+    uint8_t sb[SHA3_KECCAK_SPONGE_WORDS * 8];
+  };
+  unsigned byteIndex;     /* 0..7--the next byte after the set one
+                           * (starts from 0; 0--none are buffered) */
+  unsigned wordIndex;     /* 0..24--the next word to integrate input
+                           * (starts from 0) */
+  unsigned capacityWords; /* the double size of the hash output in
+                           * words (e.g. 16 for Keccak 512) */
+} sha3_context;
+
+enum SHA3_FLAGS { SHA3_FLAGS_NONE = 0, SHA3_FLAGS_KECCAK = 1 };
+
+enum SHA3_RETURN { SHA3_RETURN_OK = 0, SHA3_RETURN_BAD_PARAMS = 1 };
+typedef enum SHA3_RETURN sha3_return_t;
+
+/* For Init or Reset call these: */
+sha3_return_t sha3_Init(void *priv, unsigned bitSize);
+void keccakf(uint64_t s[25]);
+
+void sha3_Init256(void *priv);
+void sha3_Init384(void *priv);
+void sha3_Init512(void *priv);
+
+enum SHA3_FLAGS sha3_SetFlags(void *priv, enum SHA3_FLAGS);
+
+void sha3_Update(void *priv, void const *bufIn, size_t len);
+
+void const *sha3_Finalize(void *priv);
+
+/* Single-call hashing */
+sha3_return_t sha3_HashBuffer(
+    unsigned bitSize,      /* 256, 384, 512 */
+    enum SHA3_FLAGS flags, /* SHA3_FLAGS_NONE or SHA3_FLAGS_KECCAK */
+    const void *in,
+    unsigned inBytes,
+    void *out,
+    unsigned outBytes); /* up to bitSize/8; truncation OK */
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // SCHNORRKEL_CRUST_KECCAK_H

--- a/test/sr25519/strobe.hpp
+++ b/test/sr25519/strobe.hpp
@@ -51,7 +51,7 @@ class Strobe final {
   static constexpr Flags kFlag_M = 0x10;
   static constexpr Flags kFlag_K = 0x20;
 
-  uint8_t raw_data[kBufferSize + kAlignment - 1ull + 3ull];
+  uint8_t raw_data_[kBufferSize + kAlignment - 1ull + 3ull];
   uint8_t *const buffer_;
 
   struct State {
@@ -143,7 +143,7 @@ class Strobe final {
 public:
   Strobe()
       : buffer_{reinterpret_cast<uint8_t *>(
-            roundUp<kAlignment>(reinterpret_cast<uintptr_t>(raw_data)))},
+            roundUp<kAlignment>(reinterpret_cast<uintptr_t>(raw_data_)))},
         state_{.current_position{*(buffer_ + kBufferSize)},
                .begin_position{*(buffer_ + kBufferSize + 1ull)},
                .current_state{*(buffer_ + kBufferSize + 2ull)}} {}

--- a/test/sr25519/strobe.hpp
+++ b/test/sr25519/strobe.hpp
@@ -1,0 +1,226 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SCHNORRKEL_CRUST_STROBE_H
+#define SCHNORRKEL_CRUST_STROBE_H
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <tuple>
+#include <type_traits>
+
+#include <gsl/span>
+
+#include "keccak.h"
+
+namespace primitives {
+
+/**
+ * Obtain closest multiple of X that is greater or equal to given number
+ * @tparam X multiple that is POW of 2
+ * @tparam T type of number
+ * @param t given number
+ * @return closest multiple
+ */
+template <size_t X, typename T> inline T roundUp(T t) {
+  static_assert((X & (X - 1)) == 0, "Must be POW 2!");
+  static_assert(X != 0, "Must not be 0!");
+  return (t + (X - 1)) & ~(X - 1);
+}
+
+/**
+ * C++ implementation of
+ * https://strobe.sourceforge.io/
+ */
+class Strobe final {
+  static constexpr size_t kBufferSize = 200ull;
+  static constexpr size_t kAlignment = 8ull;
+  static constexpr uint8_t kStrobeR = 166;
+
+  using Flags = uint8_t;
+  using Position = uint8_t;
+
+  static constexpr Flags kFlag_NU = 0x00; // NU = No Use
+  static constexpr Flags kFlag_I = 0x01;
+  static constexpr Flags kFlag_A = 0x02;
+  static constexpr Flags kFlag_C = 0x04;
+  static constexpr Flags kFlag_T = 0x08;
+  static constexpr Flags kFlag_M = 0x10;
+  static constexpr Flags kFlag_K = 0x20;
+
+  uint8_t raw_data[kBufferSize + kAlignment - 1ull + 3ull];
+  uint8_t *const buffer_;
+
+  struct State {
+    Position &current_position;
+    Position &begin_position;
+    Flags &current_state;
+  } state_;
+
+  template <typename T, size_t kOffset = 0ull> constexpr T *as() {
+    static_assert(kOffset < count<T>(), "Overflow!");
+    return (reinterpret_cast<T *>(buffer_) + kOffset); // NOLINT
+  }
+
+  template <typename T> T *as(Position offset) {
+    assert(static_cast<size_t>(offset) < count<T>());
+    return (as<T>() + offset);
+  }
+
+  template <typename T> static constexpr size_t count() {
+    static_assert(!std::is_reference_v<T>, "Can not be a reference type.");
+    static_assert(!std::is_pointer_v<T>, "Can not be a pointer.");
+    static_assert(std::is_integral_v<T>, "Cast to non integral type.");
+    return kBufferSize / sizeof(T);
+  }
+
+  template <size_t kOffset, typename T, size_t N>
+  void load(const T (&data)[N]) { // NOLINT
+    static_assert(kOffset + N <= count<T>(), "Load overflows!");
+    std::memcpy(as<T, kOffset>(), data, N);
+  }
+
+  template <typename T, size_t N> void absorb(const T (&src)[N]) {
+    for (const auto i : src) {
+      *as<uint8_t>(state_.current_position++) ^= static_cast<uint8_t>(i);
+      if (kStrobeR == state_.current_position) {
+        runF();
+      }
+    }
+  }
+
+  template <typename T, size_t N> void overwrite(const T (&src)[N]) {
+    for (const auto i : src) {
+      *as<uint8_t>(state_.current_position++) = static_cast<uint8_t>(i);
+      if (kStrobeR == state_.current_position) {
+        runF();
+      }
+    }
+  }
+
+  template <typename T, size_t N> void squeeze(T (&src)[N]) {
+    for (auto &i : src) {
+      i = static_cast<T>(*as<uint8_t>(state_.current_position));
+      *as<uint8_t>(state_.current_position++) = 0;
+      if (kStrobeR == state_.current_position) {
+        runF();
+      }
+    }
+  }
+
+  template <bool kMore, Flags kFlags> void beginOp() {
+    static_assert((kFlags & kFlag_T) == 0, "T flag doesn't support");
+    if constexpr (kMore) {
+      assert(state_.current_state == kFlags);
+      return;
+    }
+
+    const auto old_begin = state_.begin_position;
+    state_.begin_position = state_.current_position + 1;
+    state_.current_state = kFlags;
+    absorb({old_begin, kFlags});
+
+    if constexpr (0 != (kFlags & (kFlag_C | kFlag_K))) {
+      if (state_.current_position != 0) {
+        runF();
+      }
+    }
+  }
+
+  void runF() {
+    *as<uint8_t>(state_.current_position) ^= state_.begin_position;
+    *as<uint8_t>(state_.current_position + 1) ^= 0x04;
+    *as<uint8_t>(kStrobeR + 1) ^= 0x80;
+    keccakf(as<uint64_t>());
+
+    state_.current_position = 0;
+    state_.begin_position = 0;
+  }
+
+public:
+  Strobe()
+      : buffer_{reinterpret_cast<uint8_t *>(
+            roundUp<kAlignment>(reinterpret_cast<uintptr_t>(raw_data)))},
+        state_{.current_position{*(buffer_ + kBufferSize)},
+               .begin_position{*(buffer_ + kBufferSize + 1ull)},
+               .current_state{*(buffer_ + kBufferSize + 2ull)}} {}
+
+  Strobe(const Strobe &) = delete;
+  Strobe &operator=(const Strobe &) = delete;
+
+  Strobe(Strobe &&) = delete;
+  Strobe &operator=(Strobe &&) = delete;
+
+  template <typename T, size_t N> void initialize(const T (&label)[N]) {
+    constexpr bool kUseRuntimeCalculation = false;
+
+    if constexpr (kUseRuntimeCalculation) {
+      std::memset(as<uint8_t>(), 0, count<uint8_t>());
+      load<0ull>((uint8_t[6]){1, kStrobeR + 2, 1, 0, 1, 96});
+      load<6ull>("STROBEv1.0.2");
+      keccakf(as<uint64_t>());
+    } else {
+      load<0ull>((uint8_t[kBufferSize]){
+          0x9c, 0x6d, 0x16, 0x8f, 0xf8, 0xfd, 0x55, 0xda, 0x2a, 0xa7, 0x3c,
+          0x23, 0x55, 0x65, 0x35, 0x63, 0xdc, 0xc,  0x47, 0x5c, 0x55, 0x15,
+          0x26, 0xf6, 0x73, 0x3b, 0xea, 0x22, 0xf1, 0x6c, 0xb5, 0x7c, 0xd3,
+          0x1f, 0x68, 0x2e, 0x66, 0xe,  0xe9, 0x12, 0x82, 0x4a, 0x77, 0x22,
+          0x1,  0xee, 0x13, 0x94, 0x22, 0x6f, 0x4a, 0xfc, 0xb6, 0x2d, 0x33,
+          0x12, 0x93, 0xcc, 0x92, 0xe8, 0xa6, 0x24, 0xac, 0xf6, 0xe1, 0xb6,
+          0x0,  0x95, 0xe3, 0x22, 0xbb, 0xfb, 0xc8, 0x45, 0xe5, 0xb2, 0x69,
+          0x95, 0xfe, 0x7d, 0x7c, 0x84, 0x13, 0x74, 0xd1, 0xff, 0x58, 0x98,
+          0xc9, 0x2e, 0xe0, 0x63, 0x6b, 0x6,  0x72, 0x73, 0x21, 0xc9, 0x2a,
+          0x60, 0x39, 0x7,  0x3,  0x53, 0x49, 0xcc, 0xbb, 0x1b, 0x92, 0xb7,
+          0xb0, 0x5,  0x7e, 0x8f, 0xa8, 0x7f, 0xce, 0xbc, 0x7e, 0x88, 0x65,
+          0x6f, 0xcb, 0x45, 0xae, 0x4,  0xbc, 0x34, 0xca, 0xbe, 0xae, 0xbe,
+          0x79, 0xd9, 0x17, 0x50, 0xc0, 0xe8, 0xbf, 0x13, 0xb9, 0x66, 0x50,
+          0x4d, 0x13, 0x43, 0x59, 0x72, 0x65, 0xdd, 0x88, 0x65, 0xad, 0xf9,
+          0x14, 0x9,  0xcc, 0x9b, 0x20, 0xd5, 0xf4, 0x74, 0x44, 0x4,  0x1f,
+          0x97, 0xb6, 0x99, 0xdd, 0xfb, 0xde, 0xe9, 0x1e, 0xa8, 0x7b, 0xd0,
+          0x9b, 0xf8, 0xb0, 0x2d, 0xa7, 0x5a, 0x96, 0xe9, 0x47, 0xf0, 0x7f,
+          0x5b, 0x65, 0xbb, 0x4e, 0x6e, 0xfe, 0xfa, 0xa1, 0x6a, 0xbf, 0xd9,
+          0xfb, 0xf6});
+    }
+
+    state_.current_position = 0;
+    state_.current_state = kFlag_NU;
+    state_.begin_position = 0;
+
+    metaAd<false>(label);
+  }
+
+  template <bool kMore, typename T, size_t N> void ad(const T (&src)[N]) {
+    beginOp<kMore, kFlag_A>();
+    absorb(src);
+  }
+
+  template <bool kMore, typename T, size_t N> void metaAd(const T (&label)[N]) {
+    beginOp<kMore, kFlag_M | kFlag_A>();
+    absorb(label);
+  }
+
+  template <bool kMore, typename T, size_t N> void prf(T (&data)[N]) {
+    beginOp<kMore, kFlag_I | kFlag_A | kFlag_C>();
+    squeeze(data);
+  }
+
+  template <bool kMore, typename T, size_t N> void key(const T (&data)[N]) {
+    beginOp<kMore, kFlag_A | kFlag_C>();
+    overwrite(data);
+  }
+
+  auto data() {
+    return gsl::make_span(as<const uint8_t>(), count<uint8_t>() + 3ull);
+  }
+
+  auto state() const {
+    return state_;
+  }
+};
+
+} // namespace primitives
+
+#endif // SCHNORRKEL_CRUST_STROBE_H

--- a/test/sr25519/transcript.hpp
+++ b/test/sr25519/transcript.hpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SCHNORRKEL_CRUST_TRANSCRIPT_HPP
+#define SCHNORRKEL_CRUST_TRANSCRIPT_HPP
+
+
+#include "strobe.hpp"
+
+namespace primitives {
+
+/**
+ * C++ implementation of
+ * https://github.com/dalek-cryptography/merlin
+ */
+class Transcript final {
+  Transcript(const Transcript &) = delete;
+  Transcript &operator=(const Transcript &) = delete;
+
+  Transcript(Transcript &&) = delete;
+  Transcript &operator=(Transcript &&) = delete;
+
+  Strobe strobe_;
+
+  template <typename T>
+  inline void decompose(const T &value, uint8_t (&dst)[sizeof(value)]) {
+    static_assert(std::is_pod_v<T>, "T must be pod!");
+    static_assert(!std::is_reference_v<T>, "T must not be a reference!");
+
+    for (size_t i = 0; i < sizeof(value); ++i) {
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+      dst[sizeof(value) - i - 1] =
+#else
+      dst[i] =
+#endif
+          static_cast<uint8_t>((value >> (8 * i)) & 0xff);
+    }
+  }
+
+public:
+  Transcript() = default;
+
+  template <typename T, size_t N>
+  void initialize(const T (&label)[N]) {
+    strobe_.initialize(
+        (uint8_t[11]){'M', 'e', 'r', 'l', 'i', 'n', ' ', 'v', '1', '.', '0'});
+    append_message((uint8_t[]){'d', 'o', 'm', '-', 's', 'e', 'p'}, label);
+  }
+
+  template <typename T, size_t N, typename K, size_t M>
+  void append_message(const T (&label)[N], const K (&msg)[M]) {
+    const uint32_t data_len = sizeof(msg);
+    strobe_.metaAd<false>(label);
+
+    uint8_t tmp[sizeof(data_len)];
+    decompose(data_len, tmp);
+
+    strobe_.metaAd<true>(tmp);
+    strobe_.ad<false>(msg);
+  }
+
+  template <typename T, size_t N>
+  void append_message(const T (&label)[N], const uint64_t value) {
+    uint8_t tmp[sizeof(value)];
+    decompose(value, tmp);
+    append_message(label, tmp);
+  }
+
+  auto data() {
+    return strobe_.data();
+  }
+
+  auto state() const {
+    return strobe_.state();
+  }
+};
+
+}  // namespace primitives
+
+#endif // SCHNORRKEL_CRUST_TRANSCRIPT_HPP

--- a/test/sr25519/vrf.cpp
+++ b/test/sr25519/vrf.cpp
@@ -74,47 +74,46 @@ TEST(VrfTest, SignAndCheck) {
   EXPECT_TRUE(res1.is_less);
 }
 
-TEST(VrfTest, SignAndVerifyTranscript) {
-  auto keypair =
-      "915bb406968655c3412df5773c3de3dee9f6da84668b5de8d2f34d0304d20b0bac5ea3a293dfd93859ee64a5b825937753864c19be857f045758dcae10259ba1049b21bb9cb88471b9dadb50b925135cfb291a463043635b58599a2d01b1fd18"_unhex;
-  std::array<uint8_t, SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE>
-      out_and_proof {};
-
-  auto message = "Hello, world!"_v;
-  auto limit = std::vector<uint8_t>(16, 0xAA);
-
+template <size_t MsgBufSize>
+Strobe128 makeTranscript(std::string_view message) {
   primitives::Transcript t;
   t.initialize({'B', 'A', 'B', 'E'});
-  char msg_array[14];
-  std::memcpy(msg_array, message.data(), message.size());
-  t.append_message({'m', 'e', 's', 's', 'a', 'g', 'e'}, msg_array);
+  char msg_buf[MsgBufSize];
+  std::fill_n(msg_buf, MsgBufSize, 0);
+  std::memcpy(msg_buf, message.data(), message.size());
+  t.append_message({'m', 'e', 's', 's', 'a', 'g', 'e'}, msg_buf);
 
   Strobe128 strobe;
   std::memcpy(strobe.state, t.data().data(), t.data().size());
   strobe.pos = t.state().current_position;
   strobe.cur_flags = t.state().current_state;
   strobe.pos_begin = t.state().begin_position;
+  return strobe;
+}
+
+TEST(VrfTest, SignAndVerifyTranscript) {
+  auto keypair =
+      "915bb406968655c3412df5773c3de3dee9f6da84668b5de8d2f34d0304d20b0bac5ea3a293dfd93859ee64a5b825937753864c19be857f045758dcae10259ba1049b21bb9cb88471b9dadb50b925135cfb291a463043635b58599a2d01b1fd18"_unhex;
+  std::array<uint8_t, SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE>
+      out_and_proof {};
+
+  auto message = "Hello, world!"s;
+  auto limit = std::vector<uint8_t>(16, 0xAA);
+
+  auto strobe1 = makeTranscript<14>(message);
 
   auto res1 =
       sr25519_vrf_sign_transcript(out_and_proof.data(), keypair.data(),
-                                  &strobe, limit.data());
+                                  &strobe1, limit.data());
   ASSERT_EQ(res1.result, SR25519_SIGNATURE_RESULT_OK);
-  EXPECT_TRUE(res1.is_less);
+  bool less = res1.is_less;
 
-  primitives::Transcript t1;
-  t1.initialize({'B', 'A', 'B', 'E'});
-  char msg_array1[14];
-  std::memcpy(msg_array1, message.data(), message.size());
-  t1.append_message({'m', 'e', 's', 's', 'a', 'g', 'e'}, msg_array1);
-  std::memcpy(strobe.state, t.data().data(), t.data().size());
-  strobe.pos = t.state().current_position;
-  strobe.cur_flags = t.state().current_state;
-  strobe.pos_begin = t.state().begin_position;
+  auto strobe2 = makeTranscript<14>(message);
 
   auto res2 = sr25519_vrf_verify_transcript(
-      keypair.data() + 64, &strobe, out_and_proof.data(),
+      keypair.data() + 64, &strobe2, out_and_proof.data(),
       out_and_proof.data() + SR25519_VRF_OUTPUT_SIZE, limit.data());
   ASSERT_EQ(res2.result, SR25519_SIGNATURE_RESULT_OK);
-  ASSERT_TRUE(res2.is_less);
+  ASSERT_EQ(less, res2.is_less);
 
 }

--- a/test/sr25519/vrf.cpp
+++ b/test/sr25519/vrf.cpp
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "../utils.hpp"
 #include <array>
-#include <gtest/gtest.h>
 #include <string>
+
+#include <gtest/gtest.h>
+
+#include "../utils.hpp"
 
 extern "C" {
 #include <schnorrkel/schnorrkel.h>
@@ -69,4 +71,8 @@ TEST(VrfTest, SignAndCheck) {
                                message.data(), message.size(), limit.data());
   ASSERT_EQ(res1.result, SR25519_SIGNATURE_RESULT_OK);
   EXPECT_TRUE(res1.is_less);
+}
+
+TEST(VrfTest, SignAndVerifyTranscript) {
+
 }

--- a/test/sr25519/vrf.cpp
+++ b/test/sr25519/vrf.cpp
@@ -9,15 +9,16 @@
 #include <gtest/gtest.h>
 
 #include "../utils.hpp"
+#include "transcript.hpp"
 
 extern "C" {
 #include <schnorrkel/schnorrkel.h>
 }
 
 TEST(VrfTest, Verify) {
-  auto keypair = randomKeypair();
+  auto keypair = randomKeypair(SR25519_KEYPAIR_SIZE, sr25519_keypair_from_seed);
   std::array<uint8_t, SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE>
-      out_and_proof;
+      out_and_proof {};
 
   auto message = "Hello, world!"_v;
   auto limit = std::vector<uint8_t>(16, 0xFF);
@@ -45,7 +46,7 @@ TEST(VrfTest, ResultNotLess) {
   auto keypair =
       "915bb406968655c3412df5773c3de3dee9f6da84668b5de8d2f34d0304d20b0bac5ea3a293dfd93859ee64a5b825937753864c19be857f045758dcae10259ba1049b21bb9cb88471b9dadb50b925135cfb291a463043635b58599a2d01b1fd18"_unhex;
   std::array<uint8_t, SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE>
-      out_and_proof;
+      out_and_proof {};
 
   auto message = "Hello, world!"_v;
   auto limit = std::vector<uint8_t>(16, 0x55);
@@ -61,7 +62,7 @@ TEST(VrfTest, SignAndCheck) {
   auto keypair =
       "915bb406968655c3412df5773c3de3dee9f6da84668b5de8d2f34d0304d20b0bac5ea3a293dfd93859ee64a5b825937753864c19be857f045758dcae10259ba1049b21bb9cb88471b9dadb50b925135cfb291a463043635b58599a2d01b1fd18"_unhex;
   std::array<uint8_t, SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE>
-      out_and_proof;
+      out_and_proof {};
 
   auto message = "Hello, world!"_v;
   auto limit = std::vector<uint8_t>(16, 0xAA);
@@ -74,5 +75,46 @@ TEST(VrfTest, SignAndCheck) {
 }
 
 TEST(VrfTest, SignAndVerifyTranscript) {
+  auto keypair =
+      "915bb406968655c3412df5773c3de3dee9f6da84668b5de8d2f34d0304d20b0bac5ea3a293dfd93859ee64a5b825937753864c19be857f045758dcae10259ba1049b21bb9cb88471b9dadb50b925135cfb291a463043635b58599a2d01b1fd18"_unhex;
+  std::array<uint8_t, SR25519_VRF_OUTPUT_SIZE + SR25519_VRF_PROOF_SIZE>
+      out_and_proof {};
+
+  auto message = "Hello, world!"_v;
+  auto limit = std::vector<uint8_t>(16, 0xAA);
+
+  primitives::Transcript t;
+  t.initialize({'B', 'A', 'B', 'E'});
+  char msg_array[14];
+  std::memcpy(msg_array, message.data(), message.size());
+  t.append_message({'m', 'e', 's', 's', 'a', 'g', 'e'}, msg_array);
+
+  Strobe128 strobe;
+  std::memcpy(strobe.state, t.data().data(), t.data().size());
+  strobe.pos = t.state().current_position;
+  strobe.cur_flags = t.state().current_state;
+  strobe.pos_begin = t.state().begin_position;
+
+  auto res1 =
+      sr25519_vrf_sign_transcript(out_and_proof.data(), keypair.data(),
+                                  &strobe, limit.data());
+  ASSERT_EQ(res1.result, SR25519_SIGNATURE_RESULT_OK);
+  EXPECT_TRUE(res1.is_less);
+
+  primitives::Transcript t1;
+  t1.initialize({'B', 'A', 'B', 'E'});
+  char msg_array1[14];
+  std::memcpy(msg_array1, message.data(), message.size());
+  t1.append_message({'m', 'e', 's', 's', 'a', 'g', 'e'}, msg_array1);
+  std::memcpy(strobe.state, t.data().data(), t.data().size());
+  strobe.pos = t.state().current_position;
+  strobe.cur_flags = t.state().current_state;
+  strobe.pos_begin = t.state().begin_position;
+
+  auto res2 = sr25519_vrf_verify_transcript(
+      keypair.data() + 64, &strobe, out_and_proof.data(),
+      out_and_proof.data() + SR25519_VRF_OUTPUT_SIZE, limit.data());
+  ASSERT_EQ(res2.result, SR25519_SIGNATURE_RESULT_OK);
+  ASSERT_TRUE(res2.is_less);
 
 }

--- a/test/sr25519/vrf.cpp
+++ b/test/sr25519/vrf.cpp
@@ -115,5 +115,4 @@ TEST(VrfTest, SignAndVerifyTranscript) {
       out_and_proof.data() + SR25519_VRF_OUTPUT_SIZE, limit.data());
   ASSERT_EQ(res2.result, SR25519_SIGNATURE_RESULT_OK);
   ASSERT_EQ(less, res2.is_less);
-
 }


### PR DESCRIPTION
Took changes from @iceseer 's fork, refactored a bit and added test. 

The goal is to allow passing a custom external transcript as a param in VRF functions.